### PR TITLE
Add to the IMetadataCatalog interface the method force_unindex_doc which

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 TESTS_REQUIRE = [
     'pyhamcrest',
     'zope.testing',
+    'zope.dottedname',
     'zope.testrunner',
 ]
 

--- a/src/nti/zope_catalog/interfaces.py
+++ b/src/nti/zope_catalog/interfaces.py
@@ -5,10 +5,9 @@ Interfaces related to catalogs.
 
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from zope import interface
 
@@ -89,12 +88,29 @@ class IMetadataCatalog(ICatalog):
     The nti metadata catalog.
     """
 
-    def index_doc(self, iid, ob):
+    def index_doc(iid, ob):
         """
         This may or may not update our underlying index.
         """
 
-    def force_index_doc(self, iid, ob):
+    def force_index_doc(iid, ob):
         """
         Force the underlying index to update.
+        """
+    
+    def unindex_doc(docid):
+        """
+        This may or may not update our underlying index.
+        """
+
+    def force_unindex_doc(iid):
+        """
+        Remove a document from the index.
+
+        docid: int, identifying the document
+
+        return: None
+
+        This call is a no-op if the docid isn't in the index, however,
+        after this call, the index should have no references to the docid.
         """

--- a/src/nti/zope_catalog/interfaces.py
+++ b/src/nti/zope_catalog/interfaces.py
@@ -93,17 +93,31 @@ class IMetadataCatalog(ICatalog):
         This may or may not update our underlying index.
         """
 
-    def force_index_doc(iid, ob):
+    def force_index_doc(docid, ob):
         """
-        Force the underlying index to update.
+        Add a document to the index.
+
+        docid: int, identifying the document
+
+        value: the value to be indexed
+
+        return: None
+
+        This can also be used to reindex documents.
         """
-    
+
+
+class IExtendedMetadataCatalog(IMetadataCatalog):
+    """
+    An extended nti metadata catalog.
+    """
+
     def unindex_doc(docid):
         """
         This may or may not update our underlying index.
         """
 
-    def force_unindex_doc(iid):
+    def force_unindex_doc(docid):
         """
         Remove a document from the index.
 

--- a/src/nti/zope_catalog/tests/test_interfaces.py
+++ b/src/nti/zope_catalog/tests/test_interfaces.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
+
+import unittest
+
+from zope.dottedname import resolve as dottedname
+
+
+class TestInterfaces(unittest.TestCase):
+
+    def test_import_interfaces(self):
+        dottedname.resolve('nti.zope_catalog.interfaces')


### PR DESCRIPTION
implementer classes should override to remove a document from the index