### PR TITLE
Rename and simplify the Timestamp and Float normalizers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,15 @@
 2.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Rename ``TimestampToNormalized64BitIntNormalizer`` to
+  ``TimestampTo64BitIntNormalizer`` for consistency.
+- Make ``TimestampTo64BitIntNormalizer`` subclass
+  ``TimestampNormalizer`` for simplicity.
+- Rename ``FloatToNormalized64BitIntNormalizer`` to
+  ``PersistentFloatTo64BitIntNormalizer`` for consistency and to
+  reflect its purpose.
+- Make ``PersistentFloatTo64BitIntNormalizer`` subclass
+  ``FloatTo64BitIntNormalizer``.
 
 
 1.0.0 (2017-06-15)

--- a/src/nti/zope_catalog/number.py
+++ b/src/nti/zope_catalog/number.py
@@ -42,16 +42,20 @@ class FloatTo64BitIntNormalizer(AbstractNormalizerMixin):
 
 
 @interface.implementer(INormalizer)
-class FloatToNormalized64BitIntNormalizer(Persistent,
-                                          AbstractNormalizerMixin):
+class PersistentFloatTo64BitIntNormalizer(Persistent,
+                                          FloatTo64BitIntNormalizer):
     """
-    Normalizes incoming float values to integers so
-    that can be stored in an :class:`nti.zodb_catalog.field.IntegerAttributeIndex`.
+    Persistent normalizer that can be stored in an
+    :class:`nti.zodb_catalog.field.IntegerAttributeIndex`.
+
+    .. versionchanged:: 2.0.0
+       Now subclasses ``FloatTo64BitIntNormalizer``.
+    .. versionchanged:: 2.0.0
+       Rename from ``FloatToNormalized64BitIntNormalizer`` to
+       ``PersistentFloatTo64BitIntNormalizer``.
     """
 
-    @CachedProperty
-    def _int_normalizer(self):
-        return FloatTo64BitIntNormalizer()
+    __slots__ = ()
 
-    def value(self, value):
-        return self._int_normalizer.value(value)
+#: Backwards compatibility alias.
+FloatToNormalized64BitIntNormalizer = PersistentFloatTo64BitIntNormalizer

--- a/src/nti/zope_catalog/tests/test_datetime.py
+++ b/src/nti/zope_catalog/tests/test_datetime.py
@@ -33,7 +33,7 @@ class TestDatetime(unittest.TestCase):
     field = 1
 
     def test_int_normalizer(self):
-        assert_that(TimestampTo64BitIntNormalizer().value(123456.78),
+        assert_that(TimestampTo64BitIntNormalizer._int_normalizer.value(123456.78),
                     is_(4683220298531686318))
 
     def test_timestamp_normalizer(self):


### PR DESCRIPTION
I tested them in a ZODB file storage and found no issues unpickling
older versions.